### PR TITLE
Handle missing URP Lit shader for paint projectiles

### DIFF
--- a/Assets/Materials/M_PaintBlit.mat
+++ b/Assets/Materials/M_PaintBlit.mat
@@ -1,0 +1,28 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: M_PaintBlit
+  m_Shader: {fileID: 4800000, guid: 0000000000000000f000000000000000, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 0
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs: []
+    m_Ints: []
+    m_Floats: []
+    m_Colors: []
+  m_BuildTextureStacks: []

--- a/Assets/Scripts/BallLauncher.cs
+++ b/Assets/Scripts/BallLauncher.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+public class BallLauncher : MonoBehaviour
+{
+    public Transform cameraTransform;
+    public KeyCode fireKey = KeyCode.Mouse1;
+    public float speed = 28f;
+    public float mass = 0.6f;
+    public float radius = 0.15f;
+    public PhysicMaterial physMat; // crea uno: fricción dinámica 0.2, restitución 0.65
+
+    void Update()
+    {
+        if (Input.GetKeyDown(fireKey))
+            Launch();
+    }
+
+    void Launch()
+    {
+        var go = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        go.transform.position = cameraTransform.position + cameraTransform.forward * 0.4f;
+        go.transform.localScale = Vector3.one * (radius * 2f);
+
+        var col = go.GetComponent<SphereCollider>();
+        if (physMat) col.material = physMat;
+
+        var rb = go.AddComponent<Rigidbody>();
+        rb.mass = mass;
+        rb.interpolation = RigidbodyInterpolation.Interpolate;
+        rb.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
+
+        rb.AddForce(cameraTransform.forward * speed, ForceMode.VelocityChange);
+
+        go.AddComponent<ImpactImpulse>(); // opcional: transfiere impulso extra al contacto
+    }
+}

--- a/Assets/Scripts/GameInstaller.cs
+++ b/Assets/Scripts/GameInstaller.cs
@@ -1,0 +1,88 @@
+using UnityEngine;
+
+public class GameInstaller : MonoBehaviour
+{
+    [Header("Scene")]
+    public Material paintableMaterial;   // Asigna un material que use URP_PaintableShader
+    public PhysicMaterial realisticPhysMat;
+
+    void Awake()
+    {
+        // Luz
+        var lightGO = new GameObject("Directional Light");
+        var light = lightGO.AddComponent<Light>();
+        light.type = LightType.Directional;
+        light.intensity = 1.2f;
+        light.transform.rotation = Quaternion.Euler(50, -30, 0);
+
+        // Suelo
+        var floor = GameObject.CreatePrimitive(PrimitiveType.Plane);
+        floor.name = "Floor";
+        floor.transform.localScale = new Vector3(4, 1, 4);
+        floor.GetComponent<MeshRenderer>().material = MakePaintableMat();
+        floor.AddComponent<Paintable>();
+
+        // Paredes
+        CreateWall(new Vector3(0, 2.5f, 20), new Vector3(40, 5, 1));
+        CreateWall(new Vector3(0, 2.5f, -20), new Vector3(40, 5, 1));
+        CreateWall(new Vector3(20, 2.5f, 0), new Vector3(1, 5, 40));
+        CreateWall(new Vector3(-20, 2.5f, 0), new Vector3(1, 5, 40));
+
+        // Objetos pintables sueltos
+        for (int i = 0; i < 6; i++)
+        {
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.position = new Vector3(Random.Range(-8, 8), 0.5f, Random.Range(5, 15));
+            cube.GetComponent<MeshRenderer>().material = MakePaintableMat();
+            cube.AddComponent<Paintable>();
+
+            // algunos con rigidbody para que reciban impulsos
+            if (i % 2 == 0)
+            {
+                var rb = cube.AddComponent<Rigidbody>();
+                rb.mass = 3f;
+                rb.interpolation = RigidbodyInterpolation.Interpolate;
+                if (realisticPhysMat) cube.GetComponent<Collider>().material = realisticPhysMat;
+            }
+        }
+
+        // FPS Controller
+        var player = new GameObject("Player");
+        var cam = new GameObject("Main Camera");
+        cam.tag = "MainCamera";
+        cam.AddComponent<Camera>();
+        cam.transform.SetParent(player.transform);
+        cam.transform.localPosition = new Vector3(0, 1.6f, 0);
+
+        var ctrl = player.AddComponent<MinimalFPSController>();
+        ctrl.cameraTransform = cam.transform;
+
+        // PaintGun
+        var gun = player.AddComponent<PaintGun>();
+        gun.cameraTransform = cam.transform;
+
+        // Ball Launcher
+        var ball = player.AddComponent<BallLauncher>();
+        ball.cameraTransform = cam.transform;
+
+        player.transform.position = new Vector3(0, 1.8f, -10);
+    }
+
+    void CreateWall(Vector3 center, Vector3 size)
+    {
+        var wall = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        wall.name = "Wall";
+        wall.transform.position = center;
+        wall.transform.localScale = size;
+        wall.GetComponent<MeshRenderer>().material = MakePaintableMat();
+        wall.AddComponent<Paintable>();
+    }
+
+    Material MakePaintableMat()
+    {
+        var mat = new Material(Shader.Find("Universal Render Pipeline/URP_Paintable"));
+        // base color gris claro
+        mat.SetColor("_BaseColor", new Color(0.7f, 0.7f, 0.7f, 1f));
+        return mat;
+    }
+}

--- a/Assets/Scripts/ImpactImpulse.cs
+++ b/Assets/Scripts/ImpactImpulse.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+public class ImpactImpulse : MonoBehaviour
+{
+    public float extraImpulse = 2.5f;
+
+    void OnCollisionEnter(Collision c)
+    {
+        var rb = c.rigidbody;
+        if (rb != null) rb.AddForceAtPosition(-c.relativeVelocity.normalized * extraImpulse, c.contacts[0].point, ForceMode.Impulse);
+    }
+}

--- a/Assets/Scripts/MinimalFPSController.cs
+++ b/Assets/Scripts/MinimalFPSController.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+
+[RequireComponent(typeof(CharacterController))]
+public class MinimalFPSController : MonoBehaviour
+{
+    public Transform cameraTransform;
+    public float moveSpeed = 6f;
+    public float mouseSensitivity = 2.2f;
+    public float gravity = -9.81f;
+
+    CharacterController cc;
+    float pitch = 0f;
+    Vector3 velocity;
+
+    void Start()
+    {
+        cc = GetComponent<CharacterController>();
+        cc.height = 1.8f;
+        cc.center = new Vector3(0, 0.9f, 0);
+        Cursor.lockState = CursorLockMode.Locked;
+    }
+
+    void Update()
+    {
+        // Mouse look
+        float mx = Input.GetAxis("Mouse X") * mouseSensitivity;
+        float my = Input.GetAxis("Mouse Y") * mouseSensitivity;
+        transform.Rotate(0, mx, 0);
+        pitch = Mathf.Clamp(pitch - my, -85, 85);
+        cameraTransform.localEulerAngles = new Vector3(pitch, 0, 0);
+
+        // Move
+        float h = Input.GetAxis("Horizontal");
+        float v = Input.GetAxis("Vertical");
+        Vector3 dir = (transform.right * h + transform.forward * v);
+        cc.Move(dir * moveSpeed * Time.deltaTime);
+
+        // Gravity
+        if (cc.isGrounded && velocity.y < 0) velocity.y = -2f;
+        velocity.y += gravity * Time.deltaTime;
+        cc.Move(velocity * Time.deltaTime);
+    }
+}

--- a/Assets/Scripts/PaintGun.cs
+++ b/Assets/Scripts/PaintGun.cs
@@ -1,0 +1,90 @@
+using UnityEngine;
+using UnityEngine.Rendering;
+
+public class PaintGun : MonoBehaviour
+{
+    public Transform cameraTransform;
+    public float fireRate = 10f;
+    public float muzzleVelocity = 40f;
+    public float spread = 0.5f;
+    public Color paintColor = new Color(0.1f, 0.6f, 1f, 1f);
+    public float paintRadius = 0.06f; // metros aproximados
+
+    float nextFire;
+
+    void Update()
+    {
+        if (Input.GetMouseButton(0) && Time.time >= nextFire)
+        {
+            nextFire = Time.time + 1f / fireRate;
+            Fire();
+        }
+    }
+
+    static readonly int BaseColorId = Shader.PropertyToID("_BaseColor");
+    static readonly int ColorId = Shader.PropertyToID("_Color");
+    static Shader cachedProjectileShader;
+
+    void Fire()
+    {
+        var dir = cameraTransform.forward;
+        dir = Quaternion.Euler(Random.Range(-spread, spread), Random.Range(-spread, spread), 0) * dir;
+
+        var go = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        go.transform.position = cameraTransform.position + cameraTransform.forward * 0.2f;
+        go.transform.localScale = Vector3.one * 0.06f;
+        var rb = go.AddComponent<Rigidbody>();
+        rb.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
+        rb.mass = 0.02f; // paintball
+        var proj = go.AddComponent<PaintProjectile>();
+        proj.paintColor = paintColor;
+        proj.paintRadius = paintRadius;
+        rb.AddForce(dir * muzzleVelocity, ForceMode.VelocityChange);
+
+        // visual
+        var mr = go.GetComponent<MeshRenderer>();
+        var shader = GetProjectileShader();
+        Material projectileMaterial = null;
+
+        if (shader != null)
+        {
+            projectileMaterial = new Material(shader);
+            SetProjectileColor(projectileMaterial, paintColor * 1.2f);
+            mr.material = projectileMaterial;
+        }
+        else
+        {
+            Debug.LogWarning("PaintGun: Unable to find URP Lit shader, falling back to default material color.", this);
+            projectileMaterial = mr.material;
+            SetProjectileColor(projectileMaterial, paintColor * 1.2f);
+        }
+    }
+
+    static Shader GetProjectileShader()
+    {
+        if (cachedProjectileShader != null)
+            return cachedProjectileShader;
+
+        var currentPipeline = GraphicsSettings.currentRenderPipeline;
+        if (currentPipeline != null)
+            cachedProjectileShader = currentPipeline.defaultShader;
+
+        if (cachedProjectileShader == null)
+            cachedProjectileShader = Shader.Find("Universal Render Pipeline/Lit");
+
+        return cachedProjectileShader;
+    }
+
+    static void SetProjectileColor(Material material, Color color)
+    {
+        if (material == null)
+            return;
+
+        if (material.HasProperty(BaseColorId))
+            material.SetColor(BaseColorId, color);
+        else if (material.HasProperty(ColorId))
+            material.SetColor(ColorId, color);
+        else
+            material.color = color;
+    }
+}

--- a/Assets/Scripts/PaintProjectile.cs
+++ b/Assets/Scripts/PaintProjectile.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody), typeof(Collider))]
+public class PaintProjectile : MonoBehaviour
+{
+    public Color paintColor = Color.cyan;
+    public float paintRadius = 0.06f;
+    public float splashCount = 12f; // nº de “gotas” por impacto
+    public float impulse = 60f;     // fuerza radial
+
+    void OnCollisionEnter(Collision c)
+    {
+        // Impulso radial a rigidbodies cercanos
+        var hits = Physics.OverlapSphere(transform.position, paintRadius * 8f);
+        foreach (var h in hits)
+        {
+            var rb = h.attachedRigidbody;
+            if (rb != null)
+            {
+                rb.AddExplosionForce(impulse, transform.position, paintRadius * 8f, 0.1f, ForceMode.Impulse);
+            }
+        }
+
+        // “Salpicadura”: múltiples blits en torno al punto de impacto
+        if (c.contactCount > 0)
+        {
+            var contact = c.GetContact(0);
+            TryPaint(contact, 1f); // mancha central
+
+            for (int i = 0; i < splashCount; i++)
+            {
+                if (!Physics.Raycast(contact.point + contact.normal * 0.01f,
+                                     Random.insideUnitSphere, out RaycastHit hit, paintRadius * 4f))
+                    continue;
+                TryPaint(hit, Random.Range(0.3f, 0.8f));
+            }
+        }
+
+        Destroy(gameObject);
+    }
+
+    void TryPaint(ContactPoint cp, float scale)
+    {
+        var col = cp.otherCollider;
+        if (col.TryGetComponent<Paintable>(out var paintable))
+        {
+            paintable.PaintAtWorld(cp.point, cp.normal, paintColor, paintRadius * scale);
+        }
+    }
+
+    void TryPaint(RaycastHit hit, float scale)
+    {
+        if (hit.collider.TryGetComponent<Paintable>(out var paintable))
+        {
+            paintable.PaintAtWorld(hit.point, hit.normal, paintColor, paintRadius * scale);
+        }
+    }
+}

--- a/Assets/Scripts/Paintable.cs
+++ b/Assets/Scripts/Paintable.cs
@@ -1,0 +1,80 @@
+using UnityEngine;
+using UnityEngine.Rendering;
+
+[RequireComponent(typeof(Renderer))]
+public class Paintable : MonoBehaviour
+{
+    public int rtSize = 1024;
+    public RenderTexture paintRT;
+    static Material blitMat; // asigna M_PaintBlit desde Resources.FindObjectsOfTypeAll si quieres
+
+    Renderer rend;
+    MaterialPropertyBlock mpb;
+
+    void Awake()
+    {
+        rend = GetComponent<Renderer>();
+        mpb = new MaterialPropertyBlock();
+
+        // RenderTexture donde “acumulamos” pintura
+        paintRT = new RenderTexture(rtSize, rtSize, 0, RenderTextureFormat.ARGB32);
+        paintRT.enableRandomWrite = false;
+        paintRT.wrapMode = TextureWrapMode.Clamp;
+        paintRT.filterMode = FilterMode.Bilinear;
+        paintRT.Create();
+
+        rend.GetPropertyBlock(mpb);
+        mpb.SetTexture("_PaintTex", paintRT);
+        rend.SetPropertyBlock(mpb);
+
+        // material del blit
+        if (blitMat == null)
+        {
+            var mats = Resources.FindObjectsOfTypeAll<Material>();
+            foreach (var m in mats)
+                if (m && m.shader && m.shader.name == "Hidden/RT_DrawCircle") { blitMat = m; break; }
+            if (blitMat == null)
+                blitMat = new Material(Shader.Find("Hidden/RT_DrawCircle"));
+        }
+    }
+
+    public void PaintAtWorld(Vector3 worldPos, Vector3 worldNormal, Color color, float radiusMeters)
+    {
+        if (!TryGetUV(worldPos, out Vector2 uv)) return;
+
+        // Convierte radio en píxeles aproximados (usa bounds como referencia)
+        float approxMetersToUV = 1f / Mathf.Max(transform.lossyScale.x, transform.lossyScale.z);
+        float rUV = radiusMeters * approxMetersToUV;
+
+        // Parámetros para el shader de blit
+        blitMat.SetVector("_BrushUVR", new Vector4(uv.x, uv.y, rUV, 0));
+        blitMat.SetColor("_BrushColor", color);
+        blitMat.SetFloat("_Hardness", 0.7f);  // borde suave
+        blitMat.SetFloat("_Noise", 0.35f);    // salpicado
+
+        // Blit aditivo (sobre RT)
+        var tmp = RenderTexture.GetTemporary(paintRT.descriptor);
+        Graphics.Blit(paintRT, tmp);
+        Graphics.Blit(tmp, paintRT, blitMat);
+        RenderTexture.ReleaseTemporary(tmp);
+    }
+
+    bool TryGetUV(Vector3 worldPos, out Vector2 uv)
+    {
+        uv = Vector2.zero;
+        var ray = new Ray(worldPos + (worldPos - transform.position).normalized * 0.01f,
+                          (transform.position - worldPos).normalized); // pequeño rayo inverso
+
+        if (GetComponent<Collider>().Raycast(ray, out RaycastHit hit, 1f))
+        {
+            uv = hit.textureCoord;
+            return true;
+        }
+        return false;
+    }
+
+    void OnDestroy()
+    {
+        if (paintRT) paintRT.Release();
+    }
+}

--- a/Assets/Shaders/RT_DrawCircle.shader
+++ b/Assets/Shaders/RT_DrawCircle.shader
@@ -1,0 +1,55 @@
+Shader "Hidden/RT_DrawCircle"
+{
+    Properties{}
+    SubShader
+    {
+        Tags{ "RenderType"="Opaque" "Queue"="Overlay" }
+        Cull Off ZWrite Off ZTest Always
+        Pass
+        {
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata { float4 vertex:POSITION; float2 uv:TEXCOORD0; };
+            struct v2f { float4 pos:SV_POSITION; float2 uv:TEXCOORD0; };
+
+            sampler2D _MainTex; // RT actual
+            float4 _BrushUVR;   // uvx, uvy, radiusUV, _
+            float4 _BrushColor; // rgb = color
+            float  _Hardness;   // 0..1
+            float  _Noise;      // 0..1
+
+            v2f vert (appdata v){ v2f o; o.pos = UnityObjectToClipPos(v.vertex); o.uv = v.uv; return o; }
+
+            // hash noise
+            float hash21(float2 p){ p = frac(p*float2(123.34, 345.45)); p += dot(p, p+34.345); return frac(p.x*p.y); }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                float2 uv = i.uv;
+                float4 prev = tex2D(_MainTex, uv);
+
+                float2 d = uv - _BrushUVR.xy;
+                float dist = length(d) / max(_BrushUVR.z, 1e-5);
+
+                // borde suave
+                float falloff = saturate(1.0 - smoothstep(_Hardness, 1.0, dist));
+
+                // salpicado con ruido
+                float n = hash21(floor(uv * 2048.0));
+                float speckle = saturate(1.0 - step(0.9 + _Noise * 0.1, n));
+
+                float a = falloff * (0.5 + 0.5*speckle);
+
+                // Composición: color acumulativo + eleva alpha para “fuerza de mancha”
+                float3 outCol = lerp(prev.rgb, _BrushColor.rgb, a);
+                float outA = saturate(prev.a + a * 0.6);
+
+                return float4(outCol, outA);
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/Assets/Shaders/URP_PaintableShader.shader
+++ b/Assets/Shaders/URP_PaintableShader.shader
@@ -1,0 +1,56 @@
+Shader "Universal Render Pipeline/URP_Paintable"
+{
+    Properties
+    {
+        _BaseColor ("Base Color", Color) = (0.7,0.7,0.7,1)
+        _MainTex ("Base Albedo (optional)", 2D) = "white" {}
+        _PaintTex ("Paint Splatmap", 2D) = "black" {}
+        _PaintIntensity ("Paint Intensity", Range(0,2)) = 1.0
+    }
+    SubShader
+    {
+        Tags { "Queue"="Geometry" "RenderType"="Opaque" "RenderPipeline"="UniversalPipeline"}
+        LOD 200
+
+        Pass
+        {
+            Name "ForwardLit"
+            Tags{"LightMode"="UniversalForward"}
+            HLSLPROGRAM
+            #pragma vertex   vert
+            #pragma fragment frag
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS
+            #pragma multi_compile_fog
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            TEXTURE2D(_MainTex); SAMPLER(sampler_MainTex);
+            TEXTURE2D(_PaintTex); SAMPLER(sampler_PaintTex);
+            float4 _BaseColor;
+            float  _PaintIntensity;
+
+            struct Attributes { float4 positionOS:POSITION; float3 normalOS:NORMAL; float2 uv:TEXCOORD0; };
+            struct Varyings  { float4 positionHCS:SV_POSITION; float3 normalWS:TEXCOORD1; float2 uv:TEXCOORD0; float3 posWS:TEXCOORD2; };
+
+            Varyings vert(Attributes IN)
+            {
+                Varyings o;
+                o.posWS = TransformObjectToWorld(IN.positionOS.xyz);
+                o.positionHCS = TransformWorldToHClip(o.posWS);
+                o.normalWS = TransformObjectToWorldNormal(IN.normalOS);
+                o.uv = IN.uv;
+                return o;
+            }
+
+            half4 frag(Varyings IN):SV_Target
+            {
+                half4 baseAlbedo = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, IN.uv) * _BaseColor;
+                half4 paint = SAMPLE_TEXTURE2D(_PaintTex, sampler_PaintTex, IN.uv);
+                // paint.rgb = color acumulado; paint.a = intensidad acumulada
+                half mask = saturate(paint.a * _PaintIntensity);
+                half3 col = lerp(baseAlbedo.rgb, paint.rgb, mask);
+                return half4(col, 1);
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/Assets/Shaders/URP_PaintableShader.shader
+++ b/Assets/Shaders/URP_PaintableShader.shader
@@ -6,6 +6,8 @@ Shader "Universal Render Pipeline/URP_Paintable"
         _MainTex ("Base Albedo (optional)", 2D) = "white" {}
         _PaintTex ("Paint Splatmap", 2D) = "black" {}
         _PaintIntensity ("Paint Intensity", Range(0,2)) = 1.0
+        _Smoothness ("Smoothness", Range(0,1)) = 0.35
+        _Metallic ("Metallic", Range(0,1)) = 0.0
     }
     SubShader
     {
@@ -20,35 +22,152 @@ Shader "Universal Render Pipeline/URP_Paintable"
             #pragma vertex   vert
             #pragma fragment frag
             #pragma multi_compile _ _MAIN_LIGHT_SHADOWS
+            #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
+            #pragma multi_compile _ _ADDITIONAL_LIGHT_SHADOWS
+            #pragma multi_compile _ _SHADOWS_SOFT
+            #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
+            #pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
+            #pragma multi_compile _ LIGHTMAP_ON
+            #pragma multi_compile _ DIRLIGHTMAP_COMBINED
+            #pragma multi_compile _ DEBUG_DISPLAY
+            #pragma multi_compile_instancing
             #pragma multi_compile_fog
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
             TEXTURE2D(_MainTex); SAMPLER(sampler_MainTex);
             TEXTURE2D(_PaintTex); SAMPLER(sampler_PaintTex);
-            float4 _BaseColor;
-            float  _PaintIntensity;
 
-            struct Attributes { float4 positionOS:POSITION; float3 normalOS:NORMAL; float2 uv:TEXCOORD0; };
-            struct Varyings  { float4 positionHCS:SV_POSITION; float3 normalWS:TEXCOORD1; float2 uv:TEXCOORD0; float3 posWS:TEXCOORD2; };
+            CBUFFER_START(UnityPerMaterial)
+                float4 _BaseColor;
+                float4 _MainTex_ST;
+                float  _PaintIntensity;
+                float  _Smoothness;
+                float  _Metallic;
+            CBUFFER_END
+
+            float3x3 BuildTangentToWorld(float3 normalWS)
+            {
+                float3 tangentWS = normalize(cross(float3(0, 1, 0), normalWS));
+                if (all(abs(tangentWS) < 1e-5))
+                {
+                    tangentWS = normalize(cross(float3(1, 0, 0), normalWS));
+                }
+                float3 bitangentWS = cross(normalWS, tangentWS);
+                return float3x3(tangentWS, bitangentWS, normalWS);
+            }
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float3 normalOS : NORMAL;
+                float4 tangentOS : TANGENT;
+                float2 uv : TEXCOORD0;
+            #ifdef LIGHTMAP_ON
+                float2 lightmapUV : TEXCOORD1;
+            #endif
+            #ifdef DYNAMICLIGHTMAP_ON
+                float2 dynamicLightmapUV : TEXCOORD2;
+            #endif
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+                float3 positionWS : TEXCOORD0;
+                half3 normalWS : TEXCOORD1;
+                float2 uv : TEXCOORD2;
+                float3 viewDirWS : TEXCOORD3;
+                DECLARE_LIGHTMAP_OR_SH(lightmapUV, vertexSH, 4);
+            #ifdef DYNAMICLIGHTMAP_ON
+                float2 dynamicLightmapUV : TEXCOORD5;
+            #endif
+            #ifdef REQUIRES_SHADOW_COORD
+                float4 shadowCoord : TEXCOORD6;
+            #endif
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
 
             Varyings vert(Attributes IN)
             {
                 Varyings o;
-                o.posWS = TransformObjectToWorld(IN.positionOS.xyz);
-                o.positionHCS = TransformWorldToHClip(o.posWS);
-                o.normalWS = TransformObjectToWorldNormal(IN.normalOS);
-                o.uv = IN.uv;
+                UNITY_SETUP_INSTANCE_ID(IN);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                UNITY_TRANSFER_INSTANCE_ID(IN, o);
+
+                VertexPositionInputs positionInputs = GetVertexPositionInputs(IN.positionOS.xyz);
+                VertexNormalInputs normalInputs = GetVertexNormalInputs(IN.normalOS, IN.tangentOS);
+
+                o.positionCS = positionInputs.positionCS;
+                o.positionWS = positionInputs.positionWS;
+                o.normalWS = NormalizeNormalPerVertex(normalInputs.normalWS);
+                o.uv = TRANSFORM_TEX(IN.uv, _MainTex);
+                o.viewDirWS = GetWorldSpaceViewDir(o.positionWS);
+
+#ifdef LIGHTMAP_ON
+                OUTPUT_LIGHTMAP_UV(IN.lightmapUV, unity_LightmapST, o.lightmapUV);
+#else
+                OUTPUT_SH(o.normalWS, o.vertexSH);
+#endif
+
+#ifdef DYNAMICLIGHTMAP_ON
+                o.dynamicLightmapUV = IN.dynamicLightmapUV * unity_DynamicLightmapST.xy + unity_DynamicLightmapST.zw;
+#endif
+
+#ifdef REQUIRES_SHADOW_COORD
+                o.shadowCoord = GetShadowCoord(positionInputs);
+#endif
+
                 return o;
             }
 
-            half4 frag(Varyings IN):SV_Target
+            half4 frag(Varyings IN) : SV_Target
             {
+                UNITY_SETUP_INSTANCE_ID(IN);
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(IN);
+
+                half3 normalWS = NormalizeNormalPerPixel(IN.normalWS);
+
+                InputData inputData = (InputData)0;
+                inputData.positionWS = IN.positionWS;
+                inputData.normalWS = normalWS;
+                inputData.viewDirectionWS = SafeNormalize(IN.viewDirWS);
+#ifdef REQUIRES_SHADOW_COORD
+                inputData.shadowCoord = IN.shadowCoord;
+#else
+                inputData.shadowCoord = float4(0, 0, 0, 0);
+#endif
+                inputData.fogCoord = ComputeFogFactor(IN.positionCS.z);
+                inputData.vertexLighting = half3(0, 0, 0);
+                inputData.bakedGI = SAMPLE_GI(IN.lightmapUV, IN.vertexSH, normalWS);
+                inputData.shadowMask = SAMPLE_SHADOWMASK(IN.lightmapUV);
+                inputData.normalizedScreenSpaceUV = GetNormalizedScreenSpaceUV(IN.positionCS);
+                float3x3 t2w = BuildTangentToWorld(normalWS);
+                inputData.tangentToWorld = half3x3(
+                    half3(t2w[0].x, t2w[0].y, t2w[0].z),
+                    half3(t2w[1].x, t2w[1].y, t2w[1].z),
+                    half3(t2w[2].x, t2w[2].y, t2w[2].z));
+                inputData.occlusion = 1;
+
                 half4 baseAlbedo = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, IN.uv) * _BaseColor;
                 half4 paint = SAMPLE_TEXTURE2D(_PaintTex, sampler_PaintTex, IN.uv);
-                // paint.rgb = color acumulado; paint.a = intensidad acumulada
                 half mask = saturate(paint.a * _PaintIntensity);
-                half3 col = lerp(baseAlbedo.rgb, paint.rgb, mask);
-                return half4(col, 1);
+                half3 albedo = lerp(baseAlbedo.rgb, paint.rgb, mask);
+
+                SurfaceData surfaceData;
+                surfaceData.albedo = albedo;
+                surfaceData.specular = half3(0, 0, 0);
+                surfaceData.metallic = _Metallic;
+                surfaceData.smoothness = _Smoothness;
+                surfaceData.normalTS = half3(0, 0, 1);
+                surfaceData.occlusion = 1;
+                surfaceData.emission = half3(0, 0, 0);
+                surfaceData.alpha = 1;
+
+                half4 color = UniversalFragmentPBR(inputData, surfaceData);
+                color.rgb = MixFog(color.rgb, inputData.fogCoord);
+                return color;
             }
             ENDHLSL
         }


### PR DESCRIPTION
## Summary
- add GameInstaller that procedurally builds a URP test arena with paintable geometry and player rig
- implement gameplay scripts for FPS controller, paint gun/projectiles, persistent splat rendering, and a physics ball launcher
- provide URP paintable and blit shaders plus a material for the paint draw pass
- ensure paint projectiles gracefully fall back to the pipeline's default shader when URP Lit cannot be located at runtime

## Testing
- not run (Unity editor project setup)

------
https://chatgpt.com/codex/tasks/task_e_68d1c05015e483289a1e0b6a3882c418